### PR TITLE
SSSS not installed by default in Tails 4.3

### DIFF
--- a/seed.md
+++ b/seed.md
@@ -255,7 +255,7 @@ That said, the thief would have to know what the words are and either spend time
 
 If you are going to do this be sure to use a 24 word mnemonic seed (not a 12 word mnemonic seed).
 
-It is better to use [Shamir's secret sharing](https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing) to split the seed into 2 secrets, this way each piece of information is useless in isolation, and it is impossible to brute force the private key. The secrets can be recombined to recover the seed. You can also add redundancy, requiring say 2 of 3 of the secrets, or 3 of 5 (or any N of M). TailsOS comes with a pre-installed commandline tool called [ssss](http://point-at-infinity.org/ssss/) for this purpose.
+It is better to use [Shamir's secret sharing](https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing) to split the seed into 2 secrets, this way each piece of information is useless in isolation, and it is impossible to brute force the private key. The secrets can be recombined to recover the seed. You can also add redundancy, requiring say 2 of 3 of the secrets, or 3 of 5 (or any N of M). A tool called [ssss](http://point-at-infinity.org/ssss/) can be installed for this purpose.
 
 [SLIP-0039](https://github.com/satoshilabs/slips/blob/master/slip-0039.md) will greatly increase the useage of sss.
 


### PR DESCRIPTION
Change was made upstream in Debian.

```log  
* Minor improvements and updates
    - Remove some packages from the Tails image as their use is not
      widespread while consuming space for everyone. They can still be
      installed and upgraded through Additional Software (Closes: #15291).
      This includes: monkeysphere and msva-perl, gobby, hopenpgp-tools,
      keyringer, libgfshare-bin, monkeysign, paperkey, pitivi,
      pdf-redact-tools, pwgen, traverso, and ssss.
```
https://gitlab.com/Tails/tails/-/blob/master/debian/changelog#L1159